### PR TITLE
Remove unused message param

### DIFF
--- a/Interactor/AdaptiveInteractor.php
+++ b/Interactor/AdaptiveInteractor.php
@@ -52,9 +52,9 @@ class AdaptiveInteractor implements ElasticApmInteractorInterface
         return $this->interactor->addCustomContext($name, $value);
     }
 
-    public function noticeThrowable(\Throwable $e, string $message = null): void
+    public function noticeThrowable(\Throwable $e): void
     {
-        $this->interactor->noticeThrowable($e, $message);
+        $this->interactor->noticeThrowable($e);
     }
 
     public function beginTransaction(string $name, string $type, ?float $timestamp = null, ?DistributedTracingData $distributedTracingData = null): ?TransactionInterface

--- a/Interactor/BlackholeInteractor.php
+++ b/Interactor/BlackholeInteractor.php
@@ -40,7 +40,7 @@ class BlackholeInteractor implements ElasticApmInteractorInterface
         return true;
     }
 
-    public function noticeThrowable(\Throwable $e, string $message = null): void
+    public function noticeThrowable(\Throwable $e): void
     {
     }
 

--- a/Interactor/ElasticApmInteractor.php
+++ b/Interactor/ElasticApmInteractor.php
@@ -52,7 +52,7 @@ class ElasticApmInteractor implements ElasticApmInteractorInterface
         return $this->addLabel($name, $value);
     }
 
-    public function noticeThrowable(\Throwable $e, string $message = null): void
+    public function noticeThrowable(\Throwable $e): void
     {
         ElasticApm::createErrorFromThrowable($e);
     }

--- a/Interactor/ElasticApmInteractorInterface.php
+++ b/Interactor/ElasticApmInteractorInterface.php
@@ -49,7 +49,7 @@ interface ElasticApmInteractorInterface
      * Use these calls to collect errors that the PHP agent does not collect automatically and to set the callback for
      * your own error and exception handler.
      */
-    public function noticeThrowable(\Throwable $e, string $message = null): void;
+    public function noticeThrowable(\Throwable $e): void;
 
     /**
      * Starts a new transaction.

--- a/Interactor/LoggingInteractorDecorator.php
+++ b/Interactor/LoggingInteractorDecorator.php
@@ -59,13 +59,13 @@ class LoggingInteractorDecorator implements ElasticApmInteractorInterface
         return $this->interactor->addCustomContext($name, $value);
     }
 
-    public function noticeThrowable(\Throwable $e, string $message = null): void
+    public function noticeThrowable(\Throwable $e): void
     {
         $this->logger->debug('Sending exception to Elastic APM', [
             'message' => $message,
             'exception' => $e,
         ]);
-        $this->interactor->noticeThrowable($e, $message);
+        $this->interactor->noticeThrowable($e);
     }
 
     public function endCurrentTransaction(?float $duration = null): bool


### PR DESCRIPTION
ElasticApm::createErrorFromThrowable() doesn't have the posibility to set another message